### PR TITLE
Remove Prism.Composition 5.0 nuget package from View-Switching Navigation sample

### DIFF
--- a/View-Switching Navigation_Desktop/ViewSwitchingNavigation.Infrastructure/packages.config
+++ b/View-Switching Navigation_Desktop/ViewSwitchingNavigation.Infrastructure/packages.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="CommonServiceLocator" version="1.3" targetFramework="net451" />
-  <package id="Prism.Composition" version="5.0.0" targetFramework="net451" />
   <package id="Prism.Core" version="6.1.0" targetFramework="net451" />
   <package id="Prism.Wpf" version="6.1.0" targetFramework="net451" />
 </packages>


### PR DESCRIPTION
Probably the reference was overlooked and it confuses users.
