### PR TITLE
Modified post-build macro in Project 07-Modules

### DIFF
--- a/07-Modules - Directory/ModuleA/ModuleA.csproj
+++ b/07-Modules - Directory/ModuleA/ModuleA.csproj
@@ -97,7 +97,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>xcopy "$(TargetDir)$(TargetFileName)" "$(SolutionDir)\$(SolutionName)\$(OutDir)Modules\" /Y</PostBuildEvent>
+    <PostBuildEvent>xcopy "$(TargetDir)$(TargetName)*$(TargetExt)" "$(SolutionDir)$(SolutionName)$(OutDir)Modules" /Y /S</PostBuildEvent>
   </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
Modified the post-build macro to automatically copy in the OutDir all the satellite assemblies related to localization.

In this way, all the culture changes in the application will be instantly reflected in modules also.