### PR TITLE
Add sample project `LoggingWithSerilog` (Prism + Serilog)

### DIFF
--- a/30-LoggingWithSerilog/LoggingWithSerilog.sln
+++ b/30-LoggingWithSerilog/LoggingWithSerilog.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29418.71
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LoggingWithSerilog", "LoggingWithSerilog\LoggingWithSerilog.csproj", "{83F7F45F-F045-4C0E-912A-62A40D39ABFE}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{83F7F45F-F045-4C0E-912A-62A40D39ABFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{83F7F45F-F045-4C0E-912A-62A40D39ABFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{83F7F45F-F045-4C0E-912A-62A40D39ABFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{83F7F45F-F045-4C0E-912A-62A40D39ABFE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {E0310CFD-BD07-4F78-AC5F-FE3EF64EE6E8}
+	EndGlobalSection
+EndGlobal

--- a/30-LoggingWithSerilog/LoggingWithSerilog.sln.DotSettings
+++ b/30-LoggingWithSerilog/LoggingWithSerilog.sln.DotSettings
@@ -1,0 +1,9 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArgumentsStyleLiteral/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ArgumentsStyleStringLiteral/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=CommentTypo/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ConvertToUsingDeclaration/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=IdentifierTypo/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MarkupAttributeTypo/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=StringLiteralTypo/@EntryIndexedValue">DO_NOT_SHOW</s:String>
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=Xaml_002ERedundantNamespaceAlias/@EntryIndexedValue">DO_NOT_SHOW</s:String></wpf:ResourceDictionary>

--- a/30-LoggingWithSerilog/LoggingWithSerilog/App.xaml
+++ b/30-LoggingWithSerilog/LoggingWithSerilog/App.xaml
@@ -1,0 +1,9 @@
+﻿<prism:PrismApplication x:Class="LoggingWithSerilog.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:prism="http://prismlibrary.com/"
+             xmlns:local="clr-namespace:LoggingWithSerilog">
+    <Application.Resources>
+         
+    </Application.Resources>
+</prism:PrismApplication>

--- a/30-LoggingWithSerilog/LoggingWithSerilog/App.xaml.cs
+++ b/30-LoggingWithSerilog/LoggingWithSerilog/App.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System.Text;
+using System.Windows;
+using Prism.Ioc;
+using Serilog;
+using LoggingWithSerilog.Views;
+
+namespace LoggingWithSerilog
+{
+    public partial class App
+    {
+        protected override void OnStartup(StartupEventArgs e)
+        {
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Debug()
+                .WriteTo.File(path: "DemoLog.txt", encoding: Encoding.UTF8)
+                .CreateLogger();
+
+            base.OnStartup(e);
+        }
+
+        protected override void OnExit(ExitEventArgs e)
+        {
+            Log.CloseAndFlush();
+
+            base.OnExit(e);
+        }
+
+        protected override void RegisterTypes(IContainerRegistry containerRegistry)
+        {
+            containerRegistry.RegisterSerilog();
+        }
+
+        protected override Window CreateShell()
+        {
+            return Container.Resolve<MainWindow>();
+        }
+    }
+}

--- a/30-LoggingWithSerilog/LoggingWithSerilog/LoggingWithSerilog.csproj
+++ b/30-LoggingWithSerilog/LoggingWithSerilog/LoggingWithSerilog.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <UseWPF>true</UseWPF>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Prism.Unity" Version="7.2.0.1367" />
+    <PackageReference Include="Prism.Logging.Serilog" Version="7.2.0.1367" />
+
+    <PackageReference Include="Serilog" Version="2.9.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="4.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/30-LoggingWithSerilog/LoggingWithSerilog/ViewModels/MainWindowViewModel.cs
+++ b/30-LoggingWithSerilog/LoggingWithSerilog/ViewModels/MainWindowViewModel.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.IO;
+using System.Text;
+using Prism.Commands;
+using Prism.Logging;
+using Prism.Mvvm;
+
+namespace LoggingWithSerilog.ViewModels
+{
+    public class MainWindowViewModel : BindableBase
+    {
+        private readonly ILoggerFacade _logger;
+        private string _title = "Prism Serilog WPF Demo";
+
+        public MainWindowViewModel(ILoggerFacade logger)
+        {
+            _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+            LogDebugCommand = new DelegateCommand(LogDebug);
+            LogInformationCommand = new DelegateCommand(LogInformation);
+            LogWarningCommand = new DelegateCommand(LogWarning);
+            LogExceptionCommand = new DelegateCommand(LogException);
+        }
+
+        public string Title
+        {
+            get => _title;
+            set => SetProperty(ref _title, value);
+        }
+
+        public string Text
+        {
+            get
+            {
+                const string logFileName = "DemoLog.txt";
+
+                if (!File.Exists(logFileName))
+                {
+                    return null;
+                }
+
+                // FileShare.ReadWrite required for Serilog to continue writing - File.ReadAllText doesn't allow that
+                using (var stream = new FileStream(logFileName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+                {
+                    using (var reader = new StreamReader(stream, Encoding.UTF8, detectEncodingFromByteOrderMarks: true))
+                    {
+                        return reader.ReadToEnd();
+                    }
+                }
+            }
+        }
+
+        public DelegateCommand LogDebugCommand { get; }
+        public DelegateCommand LogInformationCommand { get; }
+        public DelegateCommand LogWarningCommand { get; }
+        public DelegateCommand LogExceptionCommand { get; }
+
+        private void LogDebug()
+        {
+            _logger.Log("This is a Debug message!", Category.Debug, Priority.High);
+
+            RaisePropertyChanged(nameof(Text));
+        }
+
+        private void LogInformation()
+        {
+            _logger.Log("This is an Information message!", Category.Info, Priority.High);
+
+            RaisePropertyChanged(nameof(Text));
+        }
+
+        private void LogWarning()
+        {
+            _logger.Log("This is an Warning message!", Category.Warn, Priority.High);
+
+            RaisePropertyChanged(nameof(Text));
+        }
+
+        private void LogException()
+        {
+            _logger.Log("This is an Exception message!", Category.Exception, Priority.High);
+
+            RaisePropertyChanged(nameof(Text));
+        }
+    }
+}

--- a/30-LoggingWithSerilog/LoggingWithSerilog/Views/MainWindow.xaml
+++ b/30-LoggingWithSerilog/LoggingWithSerilog/Views/MainWindow.xaml
@@ -1,0 +1,24 @@
+﻿<Window x:Class="LoggingWithSerilog.Views.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:prism="http://prismlibrary.com/"
+        prism:ViewModelLocator.AutoWireViewModel="True"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:LoggingWithSerilog"
+        mc:Ignorable="d"
+        Title="{Binding Title}" Height="490" Width="480" ResizeMode="NoResize"
+        WindowStartupLocation="CenterScreen" WindowStyle="ToolWindow">
+    <Grid Margin="0 10 0 0">
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Top">
+            <TextBlock TextWrapping="Wrap" FontSize="14" Margin="0 0 0 10">Log messages are being written to `DemoLog.txt`</TextBlock>
+            <TextBox Height="330" Width="440" Margin="5 0 0 0" Padding="5"  Text="{Binding Text, Mode=OneWay}" VerticalScrollBarVisibility="Visible" IsReadOnly="True" />
+        </StackPanel>
+        <StackPanel HorizontalAlignment="Center" VerticalAlignment="Bottom" Orientation="Horizontal">
+            <Button Margin="10 0 0 30" Padding="5" Command="{Binding LogDebugCommand}" Content="Log Debug" />
+            <Button Margin="10 0 0 30" Padding="5" Command="{Binding LogInformationCommand}" Content="Log Information" />
+            <Button Margin="10 0 0 30" Padding="5" Command="{Binding LogWarningCommand}" Content="Log Warning" />
+            <Button Margin="10 0 0 30" Padding="5" Command="{Binding LogExceptionCommand}" Content="Log Exception" />
+        </StackPanel>
+    </Grid>
+</Window>

--- a/30-LoggingWithSerilog/LoggingWithSerilog/Views/MainWindow.xaml.cs
+++ b/30-LoggingWithSerilog/LoggingWithSerilog/Views/MainWindow.xaml.cs
@@ -1,0 +1,12 @@
+﻿using System.Windows;
+
+namespace LoggingWithSerilog.Views
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+    }
+}


### PR DESCRIPTION
Sample project showing the usage of Prism's `ILoggerFacade` for writing logs, which are forwarded to a Serilog logger via [`Prism.Logging.Serilog`](https://github.com/caioproiete/prism-logging-serilog).

---

[![image](https://user-images.githubusercontent.com/177608/67525994-3f558600-f68a-11e9-94f1-00c8ccfcfce4.png)](https://github.com/caioproiete/prism-logging-serilog)